### PR TITLE
Changed log level for the command in question

### DIFF
--- a/src/main/java/datameer/awstasks/ant/ec2/AbstractEc2Task.java
+++ b/src/main/java/datameer/awstasks/ant/ec2/AbstractEc2Task.java
@@ -15,6 +15,8 @@
  */
 package datameer.awstasks.ant.ec2;
 
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
 import org.apache.log4j.NDC;
 import org.apache.tools.ant.BuildException;
 
@@ -48,8 +50,16 @@ public abstract class AbstractEc2Task extends AbstractAwsTask {
 
     private AmazonEC2 createEc2() {
         AmazonEC2Client ec2Client = new AmazonEC2Client(new BasicAWSCredentials(_accessKey, _accessSecret));
+        Level old = Logger.getRootLogger().getLevel();
+        Region region;
+        try {
+            Logger.getRootLogger().setLevel(Level.ERROR);
+            region = Region.getRegion(Regions.valueOf(_region.toUpperCase()));
+        } finally {
+            Logger.getRootLogger().setLevel(old);
+        }
         if (_region != null && !_region.trim().isEmpty()) {
-            ec2Client.setRegion(Region.getRegion(Regions.valueOf(_region.toUpperCase())));
+            ec2Client.setRegion(region);
         }
         LOG.info("connect to region " + _region);
         return ec2Client;

--- a/src/main/java/datameer/awstasks/ant/ec2/AbstractEc2Task.java
+++ b/src/main/java/datameer/awstasks/ant/ec2/AbstractEc2Task.java
@@ -50,7 +50,6 @@ public abstract class AbstractEc2Task extends AbstractAwsTask {
 
     private AmazonEC2 createEc2() {
         AmazonEC2Client ec2Client = new AmazonEC2Client(new BasicAWSCredentials(_accessKey, _accessSecret));
-        getRegioAndSuppressWarnings();
         Region region = getRegioAndSuppressWarnings();
         if (_region != null && !_region.trim().isEmpty()) {
             ec2Client.setRegion(region);

--- a/src/main/java/datameer/awstasks/ant/ec2/AbstractEc2Task.java
+++ b/src/main/java/datameer/awstasks/ant/ec2/AbstractEc2Task.java
@@ -50,6 +50,24 @@ public abstract class AbstractEc2Task extends AbstractAwsTask {
 
     private AmazonEC2 createEc2() {
         AmazonEC2Client ec2Client = new AmazonEC2Client(new BasicAWSCredentials(_accessKey, _accessSecret));
+        getRegioAndSuppressWarnings();
+        Region region = getRegioAndSuppressWarnings();
+        if (_region != null && !_region.trim().isEmpty()) {
+            ec2Client.setRegion(region);
+        }
+        LOG.info("connect to region " + _region);
+        return ec2Client;
+    }
+
+    /**
+     * Utility method to get a region. 
+     * Logger set to ERROR for the command execution
+     * to avoid the intermittent message: 
+     * WARN..."Failed to initialize regional endpoints from cloudfront"
+     * which also prints a large stacktrace polluting the log.
+     * @return region
+     */
+    private Region getRegioAndSuppressWarnings() {
         Level old = Logger.getRootLogger().getLevel();
         Region region;
         try {
@@ -58,11 +76,7 @@ public abstract class AbstractEc2Task extends AbstractAwsTask {
         } finally {
             Logger.getRootLogger().setLevel(old);
         }
-        if (_region != null && !_region.trim().isEmpty()) {
-            ec2Client.setRegion(region);
-        }
-        LOG.info("connect to region " + _region);
-        return ec2Client;
+        return region;
     }
 
     @Override


### PR DESCRIPTION
Not changing the log level leaves us with this ugly stacktrace in the logs 
```
build	15-Nov-2017 05:28:27	     [exec] BUILD SUCCESSFUL
build	15-Nov-2017 05:28:27	     [exec] 
build	15-Nov-2017 05:28:27	     [exec] Total time: 30.081 secs
build	15-Nov-2017 05:28:28	[ec2-shutdown] hadoop-cluster-hdp-2.3.0-HDP-HDP230-JOB1-v6.1  WARN [2017-11-15 04:28:28] (RegionUtils.java:148) - Failed to initialize regional endpoints from cloudfront
build	15-Nov-2017 05:28:28	[ec2-shutdown] javax.net.ssl.SSLPeerUnverifiedException: peer not authenticated
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at sun.security.ssl.SSLSessionImpl.getPeerCertificates(SSLSessionImpl.java:431)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.http.conn.ssl.AbstractVerifier.verify(AbstractVerifier.java:126)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.http.conn.ssl.SSLSocketFactory.connectSocket(SSLSocketFactory.java:572)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.http.impl.conn.DefaultClientConnectionOperator.openConnection(DefaultClientConnectionOperator.java:180)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.http.impl.conn.ManagedClientConnectionImpl.open(ManagedClientConnectionImpl.java:294)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.http.impl.client.DefaultRequestDirector.tryConnect(DefaultRequestDirector.java:645)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.http.impl.client.DefaultRequestDirector.execute(DefaultRequestDirector.java:480)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.http.impl.client.AbstractHttpClient.execute(AbstractHttpClient.java:906)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.http.impl.client.AbstractHttpClient.execute(AbstractHttpClient.java:805)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.http.impl.client.AbstractHttpClient.execute(AbstractHttpClient.java:784)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at awstasks.com.amazonaws.regions.RegionUtils.fetchFile(RegionUtils.java:252)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at awstasks.com.amazonaws.regions.RegionUtils.getRegionsFileFromCloudfront(RegionUtils.java:228)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at awstasks.com.amazonaws.regions.RegionUtils.init(RegionUtils.java:145)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at awstasks.com.amazonaws.regions.RegionUtils.getRegions(RegionUtils.java:66)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at awstasks.com.amazonaws.regions.RegionUtils.getRegion(RegionUtils.java:92)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at awstasks.com.amazonaws.regions.Region.getRegion(Region.java:45)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at datameer.awstasks.ant.ec2.AbstractEc2Task.createEc2(AbstractEc2Task.java:52)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at datameer.awstasks.ant.ec2.AbstractEc2Task.execute(AbstractEc2Task.java:64)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.UnknownElement.execute(UnknownElement.java:292)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at sun.reflect.GeneratedMethodAccessor4.invoke(Unknown Source)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at java.lang.reflect.Method.invoke(Method.java:498)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.dispatch.DispatchUtils.execute(DispatchUtils.java:106)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.Task.perform(Task.java:348)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.taskdefs.Sequential.execute(Sequential.java:68)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at java.lang.reflect.Method.invoke(Method.java:498)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.dispatch.DispatchUtils.execute(DispatchUtils.java:106)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.Task.perform(Task.java:348)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at net.sf.antcontrib.logic.TryCatchTask.execute(TryCatchTask.java:207)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.UnknownElement.execute(UnknownElement.java:292)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at sun.reflect.GeneratedMethodAccessor4.invoke(Unknown Source)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at java.lang.reflect.Method.invoke(Method.java:498)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.dispatch.DispatchUtils.execute(DispatchUtils.java:106)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.Task.perform(Task.java:348)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.taskdefs.Sequential.execute(Sequential.java:68)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.UnknownElement.execute(UnknownElement.java:292)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at sun.reflect.GeneratedMethodAccessor4.invoke(Unknown Source)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at java.lang.reflect.Method.invoke(Method.java:498)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.dispatch.DispatchUtils.execute(DispatchUtils.java:106)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.Task.perform(Task.java:348)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.taskdefs.MacroInstance.execute(MacroInstance.java:396)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.UnknownElement.execute(UnknownElement.java:292)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at sun.reflect.GeneratedMethodAccessor4.invoke(Unknown Source)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at java.lang.reflect.Method.invoke(Method.java:498)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.dispatch.DispatchUtils.execute(DispatchUtils.java:106)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.Task.perform(Task.java:348)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.Target.execute(Target.java:435)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.Target.performTasks(Target.java:456)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.Project.executeSortedTargets(Project.java:1393)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.helper.SingleCheckExecutor.executeTargets(SingleCheckExecutor.java:38)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.Project.executeTargets(Project.java:1248)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.taskdefs.Ant.execute(Ant.java:441)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.taskdefs.CallTarget.execute(CallTarget.java:105)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.UnknownElement.execute(UnknownElement.java:292)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at sun.reflect.GeneratedMethodAccessor4.invoke(Unknown Source)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at java.lang.reflect.Method.invoke(Method.java:498)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.dispatch.DispatchUtils.execute(DispatchUtils.java:106)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.Task.perform(Task.java:348)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.taskdefs.Sequential.execute(Sequential.java:68)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at net.sf.antcontrib.logic.IfTask.execute(IfTask.java:217)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at java.lang.reflect.Method.invoke(Method.java:498)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.dispatch.DispatchUtils.execute(DispatchUtils.java:106)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.TaskAdapter.execute(TaskAdapter.java:154)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.UnknownElement.execute(UnknownElement.java:292)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at sun.reflect.GeneratedMethodAccessor4.invoke(Unknown Source)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at java.lang.reflect.Method.invoke(Method.java:498)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.dispatch.DispatchUtils.execute(DispatchUtils.java:106)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.Task.perform(Task.java:348)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.Target.execute(Target.java:435)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.Target.performTasks(Target.java:456)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.Project.executeSortedTargets(Project.java:1393)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.helper.SingleCheckExecutor.executeTargets(SingleCheckExecutor.java:38)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.Project.executeTargets(Project.java:1248)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.taskdefs.Ant.execute(Ant.java:441)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.taskdefs.CallTarget.execute(CallTarget.java:105)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.UnknownElement.execute(UnknownElement.java:292)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at sun.reflect.GeneratedMethodAccessor4.invoke(Unknown Source)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at java.lang.reflect.Method.invoke(Method.java:498)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.dispatch.DispatchUtils.execute(DispatchUtils.java:106)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.Task.perform(Task.java:348)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at org.apache.tools.ant.taskdefs.Parallel$TaskRunnable.run(Parallel.java:453)
build	15-Nov-2017 05:28:28	[ec2-shutdown] 	at java.lang.Thread.run(Thread.java:748)
build	15-Nov-2017 05:28:29	[ec2-shutdown] hadoop-cluster-hdp-2.3.0-HDP-HDP230-JOB1-v6.1  INFO [2017-11-15 04:28:29] (AbstractEc2Task.java:54) - connect to region EU_WEST_1
build	15-Nov-2017 05:28:29	[ec2-shutdown] hadoop-cluster-hdp-2.3.0-HDP-HDP230-JOB1-v6.1  INFO [2017-11-15 04:28:29] (InstanceGroupImpl.java:66) - connecting to instances of group 'hadoop-cluster-
```